### PR TITLE
Added DefaultContentType; Fixed uploading files with no extensions; 

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ Task("Sync-Directory-To-S3")
         SearchFilter = "*.png",
         SearchScope = SearchScope.Recursive,
 
+        //Default content type is used when file has no extension or the content type can't be generated using extension
+        DefaultContentType = "text/html",
+
         LowerPaths = true,
         KeyPrefix = "img/",
 

--- a/src/S3/Manager/S3Manager.cs
+++ b/src/S3/Manager/S3Manager.cs
@@ -771,6 +771,7 @@ namespace Cake.AWS.S3
                             Headers = new HeadersCollection(),
 
                             GenerateContentType = settings.GenerateContentType,
+                            DefaultContentType = settings.DefaultContentType,
                             GenerateContentLength = settings.GenerateContentLength,
                             GenerateETag = settings.GenerateETag,
                             GenerateHashTag = settings.GenerateHashTag,
@@ -843,9 +844,9 @@ namespace Cake.AWS.S3
 
                 //Set ContentType
                 if (settings.GenerateContentType && String.IsNullOrEmpty(request.Headers.ContentType))
-                {
-                    request.Headers.ContentType = new Mime().Lookup(filePath.GetFilename().FullPath);
-                }
+            {
+                request.Headers.ContentType = GetContentType(filePath, settings);
+            }
 
 
 
@@ -918,7 +919,7 @@ namespace Cake.AWS.S3
                 //Set ContentType
                 if (settings.GenerateContentType && String.IsNullOrEmpty(request.Headers.ContentType))
                 {
-                    request.Headers.ContentType = new Mime().Lookup(filePath.GetFilename().FullPath);
+                    request.Headers.ContentType = GetContentType(filePath, settings);
                 }
 
 
@@ -966,7 +967,20 @@ namespace Cake.AWS.S3
                 client.PutObject(request);
             }
 
-            private Stream CompressStream(IFile file)
+        private static string GetContentType(FilePath filePath, UploadSettings settings)
+        {
+            if (!filePath.HasExtension)
+                return settings.DefaultContentType;
+
+            var mime = new Mime();
+
+            var contentType = mime.Lookup(filePath.GetFilename().FullPath);
+            if (!string.IsNullOrEmpty(settings.DefaultContentType) && contentType == mime.DefaultType())
+                contentType = settings.DefaultContentType;
+            return contentType;
+        }
+
+        private Stream CompressStream(IFile file)
             {
                 var compressed = new MemoryStream();
 

--- a/src/S3/Manager/S3Manager.cs
+++ b/src/S3/Manager/S3Manager.cs
@@ -969,10 +969,14 @@ namespace Cake.AWS.S3
 
         private static string GetContentType(FilePath filePath, UploadSettings settings)
         {
-            if (!filePath.HasExtension)
-                return settings.DefaultContentType;
-
             var mime = new Mime();
+            if (!filePath.HasExtension)
+            {
+                if (!string.IsNullOrEmpty(settings.DefaultContentType))
+                    return settings.DefaultContentType;
+
+                return mime.DefaultType();
+            }
 
             var contentType = mime.Lookup(filePath.GetFilename().FullPath);
             if (!string.IsNullOrEmpty(settings.DefaultContentType) && contentType == mime.DefaultType())

--- a/src/S3/Settings/Types/UploadSettings.cs
+++ b/src/S3/Settings/Types/UploadSettings.cs
@@ -79,7 +79,12 @@ namespace Cake.AWS.S3
             /// Generate the ContentType based on the file extension
             /// </summary>
             public bool GenerateContentType { get; set; }
-                        
+
+            /// <summary>
+            /// Content type to use when no mime type is found
+            /// </summary>
+            public string DefaultContentType { get; set; }
+
             /// <summary>
             /// Generate the ContentLength based on the file size in bytes
             /// </summary>


### PR DESCRIPTION
Added DefaultContentType setting to be used for files without extensions (e.g. when uploading a static site without .html extensions) and files for which the mime type can't be generated. It also protects the user against an error in MimeSharp which causes an exception when the file has no extension. 