### PR TITLE
Replace MimeSharp with MimeTypesMap for correct handling of .html

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -173,7 +173,7 @@ Task("Copy-Files")
 
     CopyFileToDirectory(buildDir + "/AWSSDK.Core.dll", binDir);
     CopyFileToDirectory(buildDir + "/AWSSDK.S3.dll", binDir);
-    CopyFileToDirectory(buildDir + "/MimeSharp.dll", binDir);
+    CopyFileToDirectory(buildDir + "/MimeTypesMap.dll", binDir);
 
     CopyFiles(new FilePath[] { "LICENSE", "README.md", "ReleaseNotes.md" }, binDir);
 
@@ -185,7 +185,7 @@ Task("Copy-Files")
     CopyFileToDirectory(buildDir + "/Cake.AWS.S3.dll", "./test/tools/Addins/Cake.AWS.S3/lib/net45/");
     CopyFileToDirectory(buildDir + "/AWSSDK.Core.dll", "./test/tools/Addins/Cake.AWS.S3/lib/net45/");
     CopyFileToDirectory(buildDir + "/AWSSDK.S3.dll", "./test/tools/Addins/Cake.AWS.S3/lib/net45/");
-    CopyFileToDirectory(buildDir + "/MimeSharp.dll", "./test/tools/Addins/Cake.AWS.S3/lib/net45/");
+    CopyFileToDirectory(buildDir + "/MimeTypesMap.dll", "./test/tools/Addins/Cake.AWS.S3/lib/net45/");
 });
 
 Task("Zip-Files")

--- a/nuspec/Cake.AWS.S3.nuspec
+++ b/nuspec/Cake.AWS.S3.nuspec
@@ -20,7 +20,7 @@
            <dependency id="Cake.Core" version="0.17.0" />
            <dependency id="AWSSDK.Core" version="3.3.7.1" />
            <dependency id="AWSSDK.S3" version="3.3.5.2" />
-           <dependency id="MimeSharp" version="1.0.0" />
+           <dependency id="MimeTypesMap" version="1.0.2" />
        </dependencies>
    </metadata>
 
@@ -29,7 +29,7 @@
       <file src="Cake.AWS.S3.xml" target="lib/net45" />
       <file src="AWSSDK.Core.dll" target="lib/net45" />
       <file src="AWSSDK.S3.dll" target="lib/net45" />
-      <file src="MimeSharp.dll" target="lib/net45" />
+      <file src="MimeTypesMap.dll" target="lib/net45" />
       <file src="LICENSE" />
    </files>
 </package>

--- a/src/S3/Cake.AWS.S3.csproj
+++ b/src/S3/Cake.AWS.S3.csproj
@@ -44,9 +44,8 @@
       <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MimeSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MimeSharp.1.0.0\lib\MimeSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="MimeTypesMap, Version=1.0.2.0, Culture=neutral, PublicKeyToken=1b320cc08ad5aa89, processorArchitecture=MSIL">
+      <HintPath>..\packages\MimeTypesMap.1.0.2\lib\net45\MimeTypesMap.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/S3/Manager/S3Manager.cs
+++ b/src/S3/Manager/S3Manager.cs
@@ -15,8 +15,8 @@
     using Amazon.S3;
     using Amazon.S3.Model;
     using Amazon.S3.Transfer;
+    using HeyRed.Mime;
 
-    using MimeSharp;
 #endregion
 
 
@@ -969,17 +969,17 @@ namespace Cake.AWS.S3
 
         private static string GetContentType(FilePath filePath, UploadSettings settings)
         {
-            var mime = new Mime();
+            const string defaultMimeType = "application/octet-stream";
             if (!filePath.HasExtension)
             {
                 if (!string.IsNullOrEmpty(settings.DefaultContentType))
                     return settings.DefaultContentType;
 
-                return mime.DefaultType();
+                return defaultMimeType;
             }
 
-            var contentType = mime.Lookup(filePath.GetFilename().FullPath);
-            if (!string.IsNullOrEmpty(settings.DefaultContentType) && contentType == mime.DefaultType())
+            var contentType = MimeTypesMap.GetMimeType(filePath.GetFilename().FullPath);
+            if (!string.IsNullOrEmpty(settings.DefaultContentType) && contentType == defaultMimeType)
                 contentType = settings.DefaultContentType;
             return contentType;
         }

--- a/src/S3/packages.config
+++ b/src/S3/packages.config
@@ -3,5 +3,5 @@
   <package id="AWSSDK.Core" version="3.3.7.1" targetFramework="net45" />
   <package id="AWSSDK.S3" version="3.3.5.2" targetFramework="net45" />
   <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
-  <package id="MimeSharp" version="1.0.0" targetFramework="net45" />
+  <package id="MimeTypesMap" version="1.0.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
MimeSharp does not correctly return the .html mime type. The issue has been [logged](https://github.com/ujjwol/MimeSharp/issues/7) and [fixed](https://github.com/ujjwol/MimeSharp/commit/7a9acbb8b8bb98270e330762e6a046cab7ce38ab) back in 2014. This causes s3 uploads to occasionally detect the mime type incorrectly. For me it was .html files that were having this issue. I'm guessing that there could be others. This PR replaces MimeSharp with MimeTypesMap which does not have this problem and is actively maintained. Not that there's much to maintain...