### PR TITLE
Add session token so temporary credentials may be used

### DIFF
--- a/src/Cake.AWS.S3/Extensions/Settings/S3SettingsExtensions.cs
+++ b/src/Cake.AWS.S3/Extensions/Settings/S3SettingsExtensions.cs
@@ -56,6 +56,27 @@ namespace Cake.AWS.S3
             return settings;
         }
 
+        /// <summary>
+        /// Specifies the AWS Session Token to use as credentials.
+        /// </summary>
+        /// <param name="settings">The S3 settings.</param>
+        /// <param name="key">The AWS Session Token.</param>
+        /// <returns>The same <see cref="S3Settings"/> instance so that multiple calls can be chained.</returns>
+        public static T SetSessionToken<T>(this T settings, string token) where T : S3Settings
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+            if (string.IsNullOrEmpty(token))
+            {
+                throw new ArgumentNullException("token");
+            }
+
+            settings.SessionToken = token;
+            return settings;
+        }
+
 
 
         /// <summary>

--- a/src/Cake.AWS.S3/Manager/S3Manager.cs
+++ b/src/Cake.AWS.S3/Manager/S3Manager.cs
@@ -114,6 +114,11 @@ namespace Cake.AWS.S3
                     throw new ArgumentNullException("settings.SecretKey");
                 }
 
+                if(!String.IsNullOrEmpty(settings.SessionToken))
+                {
+                    return new AmazonS3Client(settings.AccessKey, settings.SecretKey, settings.SessionToken, settings.Region);
+                }
+
                 return new AmazonS3Client(settings.AccessKey, settings.SecretKey, settings.Region);
             }
             else
@@ -761,6 +766,7 @@ namespace Cake.AWS.S3
 
                         AccessKey = settings.AccessKey,
                         SecretKey = settings.SecretKey,
+                        SessionToken = settings.SessionToken,
                         Credentials = settings.Credentials,
 
                         Region = settings.Region,
@@ -1064,6 +1070,7 @@ namespace Cake.AWS.S3
 
                         AccessKey = settings.AccessKey,
                         SecretKey = settings.SecretKey,
+                        SessionToken = settings.SessionToken,
                         Credentials = settings.Credentials,
 
                         Region = settings.Region,

--- a/src/Cake.AWS.S3/Settings/Base/S3Settings.cs
+++ b/src/Cake.AWS.S3/Settings/Base/S3Settings.cs
@@ -48,6 +48,11 @@ namespace Cake.AWS.S3
         /// The AWS Secret Access Key.
         /// </summary>
         public string SecretKey { get; set; }
+
+        /// <summary>
+        /// The AWS Session Token, if using temporary credentials.
+        /// </summary>
+        public string SessionToken { get; set; }
         
         internal AWSCredentials Credentials { get; set; }
 


### PR DESCRIPTION
In order to use temporary credentials, such as those from AssumeRole, SessionToken must be passed to the client