### PR TITLE
GH-16: Update Cake.AWS.S3 to netstandard2.0, update Cake refs to 0.26

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -56,7 +56,7 @@ Param(
 
 $CakeVersion = "0.22.0"
 $DotNetChannel = "preview";
-$DotNetVersion = "1.0.4";
+$DotNetVersion = "2.1.2";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 

--- a/nuspec/Cake.AWS.S3.nuspec
+++ b/nuspec/Cake.AWS.S3.nuspec
@@ -17,7 +17,7 @@
         <tags>Cake Script Build Amazon S3</tags>
 
         <dependencies>
-            <dependency id="Cake.Core" version="0.22.0" />
+            <dependency id="Cake.Core" version="0.26.1" />
             <dependency id="AWSSDK.Core" version="3.3.17.9" />
             <dependency id="AWSSDK.S3" version="3.3.11" />
             <dependency id="MimeTypesMap" version="1.0.2" />
@@ -33,10 +33,10 @@
         <file src="net46/Cake.AWS.S3.xml" target="lib/net46" />
         <file src="net46/Cake.AWS.S3.pdb" target="lib/net46" />
 
-        <file src="netstandard1.6/Cake.AWS.S3.dll" target="lib/netstandard1.6" />
-        <file src="netstandard1.6/Cake.AWS.S3.xml" target="lib/netstandard1.6" />
-        <file src="netstandard1.6/Cake.AWS.S3.pdb" target="lib/netstandard1.6" />
-        <file src="netstandard1.6/Cake.AWS.S3.deps.json" target="lib/netstandard1.6" />
+        <file src="netstandard2.0/Cake.AWS.S3.dll" target="lib/netstandard2.0" />
+        <file src="netstandard2.0/Cake.AWS.S3.xml" target="lib/netstandard2.0" />
+        <file src="netstandard2.0/Cake.AWS.S3.pdb" target="lib/netstandard2.0" />
+        <file src="netstandard2.0/Cake.AWS.S3.deps.json" target="lib/netstandard2.0" />
         
         <file src="LICENSE" />
     </files>

--- a/src/Cake.AWS.S3.Tests/Cake.AWS.S3.Tests.csproj
+++ b/src/Cake.AWS.S3.Tests/Cake.AWS.S3.Tests.csproj
@@ -19,19 +19,19 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Cake.Core" Version="0.22.0" />
-        <PackageReference Include="Cake.Testing" Version="0.22.0" />
+        <PackageReference Include="Cake.Core" Version="0.26.1" />
+        <PackageReference Include="Cake.Testing" Version="0.26.1" />
 
         <PackageReference Include="AWSSDK.Core" Version="3.3.17.9" />
         <PackageReference Include="AWSSDK.S3" Version="3.3.11" />
 
         <PackageReference Include="MimeTypesMap" Version="1.0.2" />
         
-        <PackageReference Include="xunit" Version="2.2.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+        <PackageReference Include="xunit" Version="2.3.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
         <PackageReference Include="Shouldly" Version="2.8.3" />
         <PackageReference Include="NSubstitute" Version="2.0.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-        <PackageReference Include="XunitXml.TestLogger" Version="1.0.3-pre-rtm" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
+        <PackageReference Include="XunitXml.TestLogger" Version="2.0.0" />
     </ItemGroup>
 </Project>

--- a/src/Cake.AWS.S3/Cake.AWS.S3.csproj
+++ b/src/Cake.AWS.S3/Cake.AWS.S3.csproj
@@ -5,7 +5,7 @@
         <PackageId>Cake.AWS.S3</PackageId>
         <OutputType>Library</OutputType>
 
-        <TargetFrameworks>net46;netstandard1.6;</TargetFrameworks>
+        <TargetFrameworks>net46;netstandard2.0;</TargetFrameworks>
 
         <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
         <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
@@ -19,7 +19,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Cake.Core" Version="0.22.0" />
+        <PackageReference Include="Cake.Core" Version="0.26.1" />
 
         <PackageReference Include="AWSSDK.Core" Version="3.3.17.9" />
         <PackageReference Include="AWSSDK.S3" Version="3.3.11" />


### PR DESCRIPTION
Summary of changes to address GH-16:
 - Update csproj to target netstandard2.0
 - Update nuspec to pack netstandard2.0
 - Update build.ps1 to pull in the current SDK refs to support netstandard2.0
 - Update Cake refs to 0.26.1
 - Also had to update testing concerns to get tests discovered/running.

This _looked_ like the the extent of the changes that were necessary.  If there are things I've missed or need adjusted, let me know.