### PR TITLE
Bump dependencies

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -44,17 +44,17 @@ Param(
     [ValidateSet("Release", "Debug")]
     [string]$Configuration = "Release",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
-	
+
     [string]$Verbosity = "Verbose",
     [switch]$WhatIf,
-	
+
     [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
     [string[]]$ScriptArgs
 )
 
 
 
-$CakeVersion = "0.29.0"
+$CakeVersion = "0.32.1"
 $DotNetChannel = "Current";
 $DotNetVersion = "2.1.2";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
@@ -99,7 +99,7 @@ else
 }
 
 # Make sure tools folder exists
-if (!(Test-Path $TOOLS_DIR)) 
+if (!(Test-Path $TOOLS_DIR))
 {
     Write-Verbose "Creating tools directory..."
     New-Item -Path $TOOLS_DIR -Type directory | out-null
@@ -148,16 +148,16 @@ Function Remove-PathVariable([string]$VariableToRemove)
 # Get .NET Core CLI path if installed.
 $FoundDotNetCliVersion = $null;
 
-if (Get-Command dotnet -ErrorAction SilentlyContinue) 
+if (Get-Command dotnet -ErrorAction SilentlyContinue)
 {
     $FoundDotNetCliVersion = dotnet --version;
 }
 
-if($FoundDotNetCliVersion -ne $DotNetVersion) 
+if($FoundDotNetCliVersion -ne $DotNetVersion)
 {
     $InstallPath = Join-Path $TOOLS_DIR "DotNet"
 
-    if (!(Test-Path $InstallPath)) 
+    if (!(Test-Path $InstallPath))
     {
         mkdir -Force $InstallPath | Out-Null;
     }
@@ -182,7 +182,7 @@ if($FoundDotNetCliVersion -ne $DotNetVersion)
 # Make sure nuget.exe exists.
 $NugetPath = Join-Path $TOOLS_DIR "nuget.exe"
 
-if (!(Test-Path $NugetPath)) 
+if (!(Test-Path $NugetPath))
 {
     Write-Host "Downloading NuGet.exe..."
     (New-Object System.Net.WebClient).DownloadFile($NugetUrl, $NugetPath);
@@ -199,12 +199,12 @@ if (!(Test-Path $NugetPath))
 # Make sure Cake has been installed.
 $CakePath = Join-Path $TOOLS_DIR "Cake.$CakeVersion/Cake.exe"
 
-if (!(Test-Path $CakePath)) 
+if (!(Test-Path $CakePath))
 {
     Write-Host "Installing Cake..."
     Invoke-Expression "&`"$NugetPath`" install Cake -Version $CakeVersion -OutputDirectory `"$TOOLS_DIR`"" | Out-Null;
 
-    if ($LASTEXITCODE -ne 0) 
+    if ($LASTEXITCODE -ne 0)
     {
         Throw "An error occured while restoring Cake from NuGet."
     }

--- a/build/scripts/build.cake
+++ b/build/scripts/build.cake
@@ -6,7 +6,7 @@ Task("Patch-Assembly-Info")
     .IsDependentOn("Restore-Nuget-Packages")
     .Does(() =>
 {
-	// Create Solution Info
+    // Create Solution Info
     var file = "./src/SolutionInfo.cs";
 
     CreateAssemblyInfo(file, new AssemblyInfoSettings
@@ -19,7 +19,7 @@ Task("Patch-Assembly-Info")
 
 
 
-	// Copy Solution Info
+    // Copy Solution Info
     foreach (string project in projectDirs)
     {
         CopyFileToDirectory(file, project + "/Properties");
@@ -34,68 +34,68 @@ Task("Build")
 {
     Information("Building {0}", solution);
 
-	// Check Logger folder
-	if (!DirectoryExists(loggerResultsDir))
-	{
-		CreateDirectory(loggerResultsDir);
-	}
-
-	// Create build settings
-	var buildSettings = new DotNetCoreMSBuildSettings
-	{
-		Verbosity = DotNetCoreVerbosity.Normal,
-		TreatAllWarningsAs = Cake.Common.Tools.DotNetCore.MSBuild.MSBuildTreatAllWarningsAs.Error,
-
-		MaxCpuCount = 3
-	};
-	
-	// Add Logger
-	buildSettings.AddFileLogger(new MSBuildFileLoggerSettings
-	{
-		LogFile = loggerResultsDir + "/build.txt",
-
-		AppendToLogFile = false,
-		ShowTimestamp = false,
-		ShowCommandLine = false,
-		ShowEventId = false,
-		ForceNoAlign = true,
-		HideItemAndPropertyList = true,
-
-		Verbosity = DotNetCoreVerbosity.Minimal
-	});
-
-
-
-	// Build Solution
-	Information("Building {0}", solution);
-
-	DotNetCoreBuild(solution, new DotNetCoreBuildSettings
+    // Check Logger folder
+    if (!DirectoryExists(loggerResultsDir))
     {
-    	Configuration = configuration,
-		
-		NoRestore = true,
-		MSBuildSettings = buildSettings
+        CreateDirectory(loggerResultsDir);
+    }
+
+    // Create build settings
+    var buildSettings = new DotNetCoreMSBuildSettings
+    {
+        Verbosity = DotNetCoreVerbosity.Normal,
+        TreatAllWarningsAs = Cake.Common.Tools.DotNetCore.MSBuild.MSBuildTreatAllWarningsAs.Error,
+
+        MaxCpuCount = 3
+    };
+
+    // Add Logger
+    buildSettings.AddFileLogger(new MSBuildFileLoggerSettings
+    {
+        LogFile = loggerResultsDir + "/build.txt",
+
+        AppendToLogFile = false,
+        ShowTimestamp = false,
+        ShowCommandLine = false,
+        ShowEventId = false,
+        ForceNoAlign = true,
+        HideItemAndPropertyList = true,
+
+        Verbosity = DotNetCoreVerbosity.Minimal
+    });
+
+
+
+    // Build Solution
+    Information("Building {0}", solution);
+
+    DotNetCoreBuild(solution, new DotNetCoreBuildSettings
+    {
+        Configuration = configuration,
+
+        NoRestore = true,
+        MSBuildSettings = buildSettings
     });
 })
 .OnError(exception =>
 {
-	List<SlackChatMessageAttachment> attachments = new List<SlackChatMessageAttachment>();
+    List<SlackChatMessageAttachment> attachments = new List<SlackChatMessageAttachment>();
 
 
 
-	// Get MsBuild Errors
-	var path = loggerResultsDir + "/build.txt";
+    // Get MsBuild Errors
+    var path = loggerResultsDir + "/build.txt";
 
-	if (FileExists(path))
-	{
-		IList<SlackChatMessageAttachment> lstAttachments = GetMsBuildAttachments(path, exception);
+    if (FileExists(path))
+    {
+        IList<SlackChatMessageAttachment> lstAttachments = GetMsBuildAttachments(path, exception);
 
-		CombineAttachments(attachments, lstAttachments);
-	}
+        CombineAttachments(attachments, lstAttachments);
+    }
 
 
 
-	// Resolve the API key.
+    // Resolve the API key.
     var token = EnvironmentVariable("SLACK_TOKEN");
 
     if (string.IsNullOrEmpty(token))
@@ -105,21 +105,21 @@ Task("Build")
 
 
 
-	// Post Message
-	SlackChatMessageSettings settings = new SlackChatMessageSettings()
-	{
-		Token = token,
-		UserName = "Cake",
-		IconUrl = new System.Uri("https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-small.png")
-	};
+    // Post Message
+    SlackChatMessageSettings settings = new SlackChatMessageSettings()
+    {
+        Token = token,
+        UserName = "Cake",
+        IconUrl = new System.Uri("https://cdn.jsdelivr.net/gh/cake-build/graphics/png/cake-small.png")
+    };
 
-	var title = "Build failed for " + appName + " v" + version;
+    var title = "Build failed for " + appName + " v" + version;
 
-	SlackChatMessageResult result = Slack.Chat.PostMessage("#code", title, attachments, settings);
+    SlackChatMessageResult result = Slack.Chat.PostMessage("#code", title, attachments, settings);
 
-	
-	
-	// Check Result
+
+
+    // Check Result
     if (result.Ok)
     {
         // Posted
@@ -131,5 +131,5 @@ Task("Build")
         Error("Failed to send message to Slack: {0}", result.Error);
     }
 
-	throw exception;
+    throw exception;
 });

--- a/build/scripts/message.cake
+++ b/build/scripts/message.cake
@@ -3,7 +3,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 Task("Slack")
-	.WithCriteria(() => !isPullRequest)
+    .WithCriteria(() => !isPullRequest)
     .Does(() =>
 {
     // Resolve the API key.
@@ -18,68 +18,68 @@ Task("Slack")
 
     // Attachments
     var text = "";
-	var packages = false;
-	
-	for (int index = 0; index < projectNames.Count; index++)
-	{
-		if (projectNames[index] != appName)
-		{
-			text += projectNames[index] + "." + version + ".nupkg";
-			packages = true;
-		}
-		
-		if (index < (projectNames.Count - 1))
-		{
-			text += "\n";
-		}
-	}
-	
-	
-	
-	// Title
-	var title = "";
-	
-	if (packages)
-	{
-		title = "Published <https://www.nuget.org/packages/" + appName + "/|" + appName + " v" + version + ">";
-	}
-	else
-	{
-		title = "Published " + appName + " v" + version;
-	}
-	
-	
-	
-	// Post Message
-	SlackChatMessageResult result;
-	
-	SlackChatMessageSettings settings = new SlackChatMessageSettings()
-	{
-		Token = token,
-		UserName = "Cake",
-		IconUrl = new System.Uri("https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-small.png")
-	};
+    var packages = false;
 
-	if (packages)
-	{
-		IList<SlackChatMessageAttachment> attachments = new List<SlackChatMessageAttachment>();
-		
-		attachments.Add(new SlackChatMessageAttachment()
-		{
-			Color = "good",
-			Text = text
-		});
-		
-		result = Slack.Chat.PostMessage("#code", title, attachments, settings);
-	}
-	else
-	{
-		result = Slack.Chat.PostMessage("#code", title, settings);
-	}
+    for (int index = 0; index < projectNames.Count; index++)
+    {
+        if (projectNames[index] != appName)
+        {
+            text += projectNames[index] + "." + version + ".nupkg";
+            packages = true;
+        }
 
-	
-	
-	// Check Result
+        if (index < (projectNames.Count - 1))
+        {
+            text += "\n";
+        }
+    }
+
+
+
+    // Title
+    var title = "";
+
+    if (packages)
+    {
+        title = "Published <https://www.nuget.org/packages/" + appName + "/|" + appName + " v" + version + ">";
+    }
+    else
+    {
+        title = "Published " + appName + " v" + version;
+    }
+
+
+
+    // Post Message
+    SlackChatMessageResult result;
+
+    SlackChatMessageSettings settings = new SlackChatMessageSettings()
+    {
+        Token = token,
+        UserName = "Cake",
+        IconUrl = new System.Uri("https://cdn.jsdelivr.net/gh/cake-build/graphics/png/cake-small.png")
+    };
+
+    if (packages)
+    {
+        IList<SlackChatMessageAttachment> attachments = new List<SlackChatMessageAttachment>();
+
+        attachments.Add(new SlackChatMessageAttachment()
+        {
+            Color = "good",
+            Text = text
+        });
+
+        result = Slack.Chat.PostMessage("#code", title, attachments, settings);
+    }
+    else
+    {
+        result = Slack.Chat.PostMessage("#code", title, settings);
+    }
+
+
+
+    // Check Result
     if (result.Ok)
     {
         //Posted

--- a/build/scripts/test.cake
+++ b/build/scripts/test.cake
@@ -5,29 +5,29 @@
 
 
 Task("Run-Unit-Tests")
-	.WithCriteria(() => (target != "Skip-Test") && (target != "Skip-Restore"))
+    .WithCriteria(() => (target != "Skip-Test") && (target != "Skip-Restore"))
     .IsDependentOn("Build")
     .Does(() =>
 {
-	// Run Test
+    // Run Test
     foreach(string test in testNames)
     {
-		Information("Running unit tests: {0}", test);
+        Information("Running unit tests: {0}", test);
 
-		string outputPath = testResultsDir + "/" + test.Replace(".Tests", "") + ".xml";
-		outputPath = MakeAbsolute(File(outputPath)).FullPath;
-		
+        string outputPath = testResultsDir + "/" + test.Replace(".Tests", "") + ".xml";
+        outputPath = MakeAbsolute(File(outputPath)).FullPath;
+
         DotNetCoreTest("./src/" + test + "/" + test + ".csproj", new DotNetCoreTestSettings
         {
-			NoRestore = true,
+            NoRestore = true,
             ArgumentCustomization = args => args.AppendSwitch("-a", " ", ".".Quote())
-												.AppendSwitch("-l", " ", ("xunit;LogFilePath=" + outputPath).Quote())
+                                                .AppendSwitch("-l", " ", ("xunit;LogFilePath=" + outputPath).Quote())
         });
     }
 
 
 
-	// Build Report
+    // Build Report
     Information("Building report");
 
     if (testNames.Count > 0)
@@ -37,44 +37,44 @@ Task("Run-Unit-Tests")
 })
 .OnError(exception =>
 {
-	// Get Errors
-	IList<string> errors = new List<string>();
+    // Get Errors
+    IList<string> errors = new List<string>();
 
-	foreach(string test in testNames)
+    foreach(string test in testNames)
     {
-		IList<XunitResult> testResults = GetXunitResults(testResultsDir + "/" + test.Replace(".Tests", "") + ".xml");
-		
-		foreach(XunitResult testResult in testResults)
-		{
-			errors.Add(testResult.Type + " => " + testResult.Method);
-			errors.Add(testResult.StackTrace);
-		}
+        IList<XunitResult> testResults = GetXunitResults(testResultsDir + "/" + test.Replace(".Tests", "") + ".xml");
+
+        foreach(XunitResult testResult in testResults)
+        {
+            errors.Add(testResult.Type + " => " + testResult.Method);
+            errors.Add(testResult.StackTrace);
+        }
     }
 
-	if (errors.Count == 0)
-	{
-		errors.Add(exception.Message);
-	}
+    if (errors.Count == 0)
+    {
+        errors.Add(exception.Message);
+    }
 
 
 
     // Get Message
-	var title = "Unit-Tests failed for " + appName + " v" + version;
+    var title = "Unit-Tests failed for " + appName + " v" + version;
     var text = "";
 
-	for (int index = 0; index < errors.Count; index++)
-	{
-		text += errors[index];
+    for (int index = 0; index < errors.Count; index++)
+    {
+        text += errors[index];
 
-		if (index < (errors.Count - 1))
-		{
-			text += "\n";
-		}
-	}
+        if (index < (errors.Count - 1))
+        {
+            text += "\n";
+        }
+    }
 
 
 
-	// Resolve the API key.
+    // Resolve the API key.
     var token = EnvironmentVariable("SLACK_TOKEN");
 
     if (string.IsNullOrEmpty(token))
@@ -84,29 +84,29 @@ Task("Run-Unit-Tests")
 
 
 
-	// Post Message
-	SlackChatMessageResult result;
-	
-	SlackChatMessageSettings settings = new SlackChatMessageSettings()
-	{
-		Token = token,
-		UserName = "Cake",
-		IconUrl = new System.Uri("https://raw.githubusercontent.com/cake-build/graphics/master/png/cake-small.png")
-	};
+    // Post Message
+    SlackChatMessageResult result;
 
-	IList<SlackChatMessageAttachment> attachments = new List<SlackChatMessageAttachment>();
-		
-	attachments.Add(new SlackChatMessageAttachment()
-	{
-		Color = "danger",
-		Text = text
-	});
-		
-	result = Slack.Chat.PostMessage("#code", title, attachments, settings);
+    SlackChatMessageSettings settings = new SlackChatMessageSettings()
+    {
+        Token = token,
+        UserName = "Cake",
+        IconUrl = new System.Uri("https://cdn.jsdelivr.net/gh/cake-build/graphics/png/cake-small.png")
+    };
 
-	
-	
-	// Check Result
+    IList<SlackChatMessageAttachment> attachments = new List<SlackChatMessageAttachment>();
+
+    attachments.Add(new SlackChatMessageAttachment()
+    {
+        Color = "danger",
+        Text = text
+    });
+
+    result = Slack.Chat.PostMessage("#code", title, attachments, settings);
+
+
+
+    // Check Result
     if (result.Ok)
     {
         // Posted
@@ -118,7 +118,7 @@ Task("Run-Unit-Tests")
         Error("Failed to send message to Slack: {0}", result.Error);
     }
 
-	throw exception;
+    throw exception;
 });
 
 
@@ -163,7 +163,7 @@ public IList<XunitResult> GetXunitResults(string filePath)
             StackTrace = stackTrace != null ? stackTrace.Value : "",
         });
     }
-            
+
     return results;
 }
 

--- a/nuspec/Cake.AWS.S3.nuspec
+++ b/nuspec/Cake.AWS.S3.nuspec
@@ -19,7 +19,7 @@
         <dependencies>
             <dependency id="AWSSDK.Core" version="3.3.100.5" />
             <dependency id="AWSSDK.S3" version="3.3.101.3" />
-            <dependency id="MimeTypesMap" version="1.0.3" />
+            <dependency id="MimeTypesMap" version="1.0.6" />
         </dependencies>
     </metadata>
 

--- a/nuspec/Cake.AWS.S3.nuspec
+++ b/nuspec/Cake.AWS.S3.nuspec
@@ -17,7 +17,6 @@
         <tags>Cake Script Build Amazon S3</tags>
 
         <dependencies>
-            <dependency id="Cake.Core" version="0.29.0" />
             <dependency id="AWSSDK.Core" version="3.3.17.9" />
             <dependency id="AWSSDK.S3" version="3.3.11" />
             <dependency id="MimeTypesMap" version="1.0.2" />
@@ -37,7 +36,7 @@
         <file src="netstandard2.0/Cake.AWS.S3.xml" target="lib/netstandard2.0" />
         <file src="netstandard2.0/Cake.AWS.S3.pdb" target="lib/netstandard2.0" />
         <file src="netstandard2.0/Cake.AWS.S3.deps.json" target="lib/netstandard2.0" />
-        
+
         <file src="LICENSE" />
     </files>
 </package>

--- a/nuspec/Cake.AWS.S3.nuspec
+++ b/nuspec/Cake.AWS.S3.nuspec
@@ -17,17 +17,13 @@
         <tags>Cake Script Build Amazon S3</tags>
 
         <dependencies>
-            <dependency id="AWSSDK.Core" version="3.3.17.9" />
-            <dependency id="AWSSDK.S3" version="3.3.11" />
-            <dependency id="MimeTypesMap" version="1.0.2" />
+            <dependency id="AWSSDK.Core" version="3.3.100.5" />
+            <dependency id="AWSSDK.S3" version="3.3.101.3" />
+            <dependency id="MimeTypesMap" version="1.0.3" />
         </dependencies>
     </metadata>
 
     <files>
-        <file src="net46/AWSSDK.Core.dll" target="lib/net46" />
-        <file src="net46/AWSSDK.S3.dll" target="lib/net46" />
-        <file src="net46/MimeTypesMap.dll" target="lib/net46" />
-
         <file src="net46/Cake.AWS.S3.dll" target="lib/net46" />
         <file src="net46/Cake.AWS.S3.xml" target="lib/net46" />
         <file src="net46/Cake.AWS.S3.pdb" target="lib/net46" />

--- a/nuspec/Cake.AWS.S3.nuspec
+++ b/nuspec/Cake.AWS.S3.nuspec
@@ -17,8 +17,8 @@
         <tags>Cake Script Build Amazon S3</tags>
 
         <dependencies>
-            <dependency id="AWSSDK.Core" version="3.3.100.5" />
-            <dependency id="AWSSDK.S3" version="3.3.101.3" />
+            <dependency id="AWSSDK.Core" version="3.3.100.8" />
+            <dependency id="AWSSDK.S3" version="3.3.101.6" />
             <dependency id="MimeTypesMap" version="1.0.6" />
         </dependencies>
     </metadata>

--- a/nuspec/Cake.AWS.S3.nuspec
+++ b/nuspec/Cake.AWS.S3.nuspec
@@ -10,7 +10,7 @@
         <summary>Amazon S3 addon for cake build.</summary>
         <licenseUrl>https://github.com/SharpeRAD/Cake.AWS.S3/LICENSE</licenseUrl>
         <projectUrl>https://github.com/SharpeRAD/Cake.AWS.S3</projectUrl>
-        <iconUrl>https://cdn.rawgit.com/cake-contrib/graphics/a5cf0f881c390650144b2243ae551d5b9f836196/png/cake-contrib-medium.png</iconUrl>
+        <iconUrl>https://cdn.jsdelivr.net/gh/cake-contrib/graphics/png/cake-contrib-medium.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <copyright>Copyright (c) Phillip Sharpe 2015</copyright>
         <releaseNotes>Initial Release</releaseNotes>

--- a/src/Cake.AWS.S3.Tests/Cake.AWS.S3.Tests.csproj
+++ b/src/Cake.AWS.S3.Tests/Cake.AWS.S3.Tests.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="AWSSDK.Core" Version="3.3.100.5" />
         <PackageReference Include="AWSSDK.S3" Version="3.3.101.3" />
 
-        <PackageReference Include="MimeTypesMap" Version="1.0.3" />
+        <PackageReference Include="MimeTypesMap" Version="1.0.6" />
 
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/Cake.AWS.S3.Tests/Cake.AWS.S3.Tests.csproj
+++ b/src/Cake.AWS.S3.Tests/Cake.AWS.S3.Tests.csproj
@@ -19,14 +19,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Cake.Core" Version="0.29.0" />
-        <PackageReference Include="Cake.Testing" Version="0.29.0" />
+        <PackageReference Include="Cake.Core" Version="0.33.0" />
+        <PackageReference Include="Cake.Testing" Version="0.33.0" />
 
         <PackageReference Include="AWSSDK.Core" Version="3.3.17.9" />
         <PackageReference Include="AWSSDK.S3" Version="3.3.11" />
 
         <PackageReference Include="MimeTypesMap" Version="1.0.2" />
-        
+
         <PackageReference Include="xunit" Version="2.3.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
         <PackageReference Include="Shouldly" Version="2.8.3" />

--- a/src/Cake.AWS.S3.Tests/Cake.AWS.S3.Tests.csproj
+++ b/src/Cake.AWS.S3.Tests/Cake.AWS.S3.Tests.csproj
@@ -22,8 +22,8 @@
         <PackageReference Include="Cake.Core" Version="0.33.0" />
         <PackageReference Include="Cake.Testing" Version="0.33.0" />
 
-        <PackageReference Include="AWSSDK.Core" Version="3.3.100.5" />
-        <PackageReference Include="AWSSDK.S3" Version="3.3.101.3" />
+        <PackageReference Include="AWSSDK.Core" Version="3.3.100.8" />
+        <PackageReference Include="AWSSDK.S3" Version="3.3.101.6" />
 
         <PackageReference Include="MimeTypesMap" Version="1.0.6" />
 

--- a/src/Cake.AWS.S3.Tests/Cake.AWS.S3.Tests.csproj
+++ b/src/Cake.AWS.S3.Tests/Cake.AWS.S3.Tests.csproj
@@ -22,16 +22,16 @@
         <PackageReference Include="Cake.Core" Version="0.33.0" />
         <PackageReference Include="Cake.Testing" Version="0.33.0" />
 
-        <PackageReference Include="AWSSDK.Core" Version="3.3.17.9" />
-        <PackageReference Include="AWSSDK.S3" Version="3.3.11" />
+        <PackageReference Include="AWSSDK.Core" Version="3.3.100.5" />
+        <PackageReference Include="AWSSDK.S3" Version="3.3.101.3" />
 
-        <PackageReference Include="MimeTypesMap" Version="1.0.2" />
+        <PackageReference Include="MimeTypesMap" Version="1.0.3" />
 
-        <PackageReference Include="xunit" Version="2.3.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-        <PackageReference Include="Shouldly" Version="2.8.3" />
-        <PackageReference Include="NSubstitute" Version="2.0.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
-        <PackageReference Include="XunitXml.TestLogger" Version="2.0.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+        <PackageReference Include="Shouldly" Version="3.0.2" />
+        <PackageReference Include="NSubstitute" Version="4.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+        <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
     </ItemGroup>
 </Project>

--- a/src/Cake.AWS.S3/Cake.AWS.S3.csproj
+++ b/src/Cake.AWS.S3/Cake.AWS.S3.csproj
@@ -21,8 +21,8 @@
     <ItemGroup>
         <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
 
-        <PackageReference Include="AWSSDK.Core" Version="3.3.100.5" />
-        <PackageReference Include="AWSSDK.S3" Version="3.3.101.3" />
+        <PackageReference Include="AWSSDK.Core" Version="3.3.100.8" />
+        <PackageReference Include="AWSSDK.S3" Version="3.3.101.6" />
 
         <PackageReference Include="MimeTypesMap" Version="1.0.6" />
     </ItemGroup>

--- a/src/Cake.AWS.S3/Cake.AWS.S3.csproj
+++ b/src/Cake.AWS.S3/Cake.AWS.S3.csproj
@@ -24,6 +24,6 @@
         <PackageReference Include="AWSSDK.Core" Version="3.3.100.5" />
         <PackageReference Include="AWSSDK.S3" Version="3.3.101.3" />
 
-        <PackageReference Include="MimeTypesMap" Version="1.0.3" />
+        <PackageReference Include="MimeTypesMap" Version="1.0.6" />
     </ItemGroup>
 </Project>

--- a/src/Cake.AWS.S3/Cake.AWS.S3.csproj
+++ b/src/Cake.AWS.S3/Cake.AWS.S3.csproj
@@ -19,11 +19,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Cake.Core" Version="0.29.0" PrivateAssets="All" />
+        <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
 
         <PackageReference Include="AWSSDK.Core" Version="3.3.17.9" />
         <PackageReference Include="AWSSDK.S3" Version="3.3.11" />
-        
+
         <PackageReference Include="MimeTypesMap" Version="1.0.2" />
     </ItemGroup>
 </Project>

--- a/src/Cake.AWS.S3/Cake.AWS.S3.csproj
+++ b/src/Cake.AWS.S3/Cake.AWS.S3.csproj
@@ -21,9 +21,9 @@
     <ItemGroup>
         <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
 
-        <PackageReference Include="AWSSDK.Core" Version="3.3.17.9" />
-        <PackageReference Include="AWSSDK.S3" Version="3.3.11" />
+        <PackageReference Include="AWSSDK.Core" Version="3.3.100.5" />
+        <PackageReference Include="AWSSDK.S3" Version="3.3.101.3" />
 
-        <PackageReference Include="MimeTypesMap" Version="1.0.2" />
+        <PackageReference Include="MimeTypesMap" Version="1.0.3" />
     </ItemGroup>
 </Project>

--- a/src/Cake.AWS.S3/Manager/S3Manager.cs
+++ b/src/Cake.AWS.S3/Manager/S3Manager.cs
@@ -183,7 +183,9 @@ namespace Cake.AWS.S3
                 request.ServerSideEncryptionCustomerMethod = ServerSideEncryptionCustomerMethod.AES256;
             }
 
+#pragma warning disable CS0618
             request.ModifiedSinceDate = settings.ModifiedDate;
+#pragma warning restore CS0618
 
             return request;
         }
@@ -203,7 +205,9 @@ namespace Cake.AWS.S3
                 request.ServerSideEncryptionCustomerMethod = ServerSideEncryptionCustomerMethod.AES256;
             }
 
+#pragma warning disable CS0618
             request.ModifiedSinceDate = settings.ModifiedDate;
+#pragma warning restore CS0618
 
             return request;
         }

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -8,5 +8,5 @@ using System.Reflection;
 [assembly: AssemblyVersion("0.6.6")]
 [assembly: AssemblyFileVersion("0.6.6")]
 [assembly: AssemblyInformationalVersion("0.6.6")]
-[assembly: AssemblyCopyright("Copyright (c) 2015 - 2018 Phillip Sharpe")]
+[assembly: AssemblyCopyright("Copyright (c) 2015 - 2019 Phillip Sharpe")]
 

--- a/test/build.ps1
+++ b/test/build.ps1
@@ -44,17 +44,17 @@ Param(
     [ValidateSet("Release", "Debug")]
     [string]$Configuration = "Release",
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
-	
+
     [string]$Verbosity = "Verbose",
     [switch]$WhatIf,
-	
+
     [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
     [string[]]$ScriptArgs
 )
 
 
 
-$CakeVersion = "0.29.0"
+$CakeVersion = "0.32.1"
 $DotNetChannel = "preview";
 $DotNetVersion = "2.1.2";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
@@ -96,7 +96,7 @@ else
 }
 
 # Make sure tools folder exists
-if (!(Test-Path $TOOLS_DIR)) 
+if (!(Test-Path $TOOLS_DIR))
 {
     Write-Verbose "Creating tools directory..."
     New-Item -Path $TOOLS_DIR -Type directory | out-null
@@ -150,16 +150,16 @@ Function Remove-PathVariable([string]$VariableToRemove)
 # Get .NET Core CLI path if installed.
 $FoundDotNetCliVersion = $null;
 
-if (Get-Command dotnet -ErrorAction SilentlyContinue) 
+if (Get-Command dotnet -ErrorAction SilentlyContinue)
 {
     $FoundDotNetCliVersion = dotnet --version;
 }
 
-if($FoundDotNetCliVersion -ne $DotNetVersion) 
+if($FoundDotNetCliVersion -ne $DotNetVersion)
 {
     $InstallPath = Join-Path $TOOLS_DIR "DotNet"
 
-    if (!(Test-Path $InstallPath)) 
+    if (!(Test-Path $InstallPath))
     {
         mkdir -Force $InstallPath | Out-Null;
     }
@@ -184,7 +184,7 @@ if($FoundDotNetCliVersion -ne $DotNetVersion)
 # Make sure nuget.exe exists.
 $NugetPath = Join-Path $TOOLS_DIR "nuget.exe"
 
-if (!(Test-Path $NugetPath)) 
+if (!(Test-Path $NugetPath))
 {
     Write-Host "Downloading NuGet.exe..."
     (New-Object System.Net.WebClient).DownloadFile($NugetUrl, $NugetPath);
@@ -201,12 +201,12 @@ if (!(Test-Path $NugetPath))
 # Make sure Cake has been installed.
 $CakePath = Join-Path $TOOLS_DIR "Cake.$CakeVersion/Cake.exe"
 
-if (!(Test-Path $CakePath)) 
+if (!(Test-Path $CakePath))
 {
     Write-Host "Installing Cake..."
     Invoke-Expression "&`"$NugetPath`" install Cake -Version $CakeVersion -OutputDirectory `"$TOOLS_DIR`"" | Out-Null;
 
-    if ($LASTEXITCODE -ne 0) 
+    if ($LASTEXITCODE -ne 0)
     {
         Throw "An error occured while restoring Cake from NuGet."
     }


### PR DESCRIPTION
Fixes #23 & #25. Example warning that would be fixed:
```
The assembly 'Cake.AWS.S3, Version=0.6.6.0, Culture=neutral, PublicKeyToken=null' 
is referencing an older version of Cake.Core (0.29.0). 
For best compatibility it should target Cake.Core version 0.33.0.
```