### PR TITLE
Adding support for AWS IAM Roles

### DIFF
--- a/nuspec/Cake.AWS.S3.nuspec
+++ b/nuspec/Cake.AWS.S3.nuspec
@@ -18,6 +18,7 @@
         <dependencies>
             <dependency id="AWSSDK.Core" version="3.5.3.1" />
             <dependency id="AWSSDK.S3" version="3.5.8.7" />
+            <dependency id="AWSSDK.SecurityToken" version="3.5.1.56" />
             <dependency id="MimeTypesMap" version="1.0.6" />
         </dependencies>
     </metadata>

--- a/src/Cake.AWS.S3.Tests/Cake.AWS.S3.Tests.csproj
+++ b/src/Cake.AWS.S3.Tests/Cake.AWS.S3.Tests.csproj
@@ -22,8 +22,9 @@
         <PackageReference Include="Cake.Core" Version="1.0.0" />
         <PackageReference Include="Cake.Testing" Version="1.0.0" />
 
-        <PackageReference Include="AWSSDK.Core" Version="3.5.3.1" />
-        <PackageReference Include="AWSSDK.S3" Version="3.5.8.7" />
+        <PackageReference Include="AWSSDK.Core" Version="3.5.3.5" />
+        <PackageReference Include="AWSSDK.S3" Version="3.5.9.3" />
+        <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.56" />
 
         <PackageReference Include="MimeTypesMap" Version="1.0.6" />
 

--- a/src/Cake.AWS.S3/Cake.AWS.S3.csproj
+++ b/src/Cake.AWS.S3/Cake.AWS.S3.csproj
@@ -21,9 +21,10 @@
     <ItemGroup>
         <PackageReference Include="Cake.Core" Version="1.0.0" PrivateAssets="All" />
 
-        <PackageReference Include="AWSSDK.Core" Version="3.5.3.1" />
-        <PackageReference Include="AWSSDK.S3" Version="3.5.8.7" />
-
+        <PackageReference Include="AWSSDK.Core" Version="3.5.3.5" />
+        <PackageReference Include="AWSSDK.S3" Version="3.5.9.3" />
+        <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.56" />
+        
         <PackageReference Include="MimeTypesMap" Version="1.0.6" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi,

We use AWS IAM Roles to switch between AWS accounts and the AWSSDK.SecurityToken library is required in order to enable the AWS SDKs to use temporary credentials. 

This PR adds the necessary dependency to enable the use of AWS IAM Roles in a multiple AWS profiles environment. 

References: 

- https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html
- https://www.nuget.org/packages/AWSSDK.SecurityToken/

Thank you for considering this PR. Please let me know if this is not the correct approach for recommending this change.